### PR TITLE
Update go version to 1.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hirano00o/edy
 
-go 1.16
+go 1.20
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.3.4
@@ -8,9 +8,12 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.0.6
 	github.com/aws/aws-sdk-go-v2/feature/dynamodb/expression v1.0.6
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.2.2
+	github.com/stretchr/testify v1.3.0
+	github.com/urfave/cli/v2 v2.3.0
+)
+
+require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/stretchr/objx v0.1.1 // indirect
-	github.com/stretchr/testify v1.3.0
-	github.com/urfave/cli/v2 v2.3.0
 )


### PR DESCRIPTION
## Description

Update go version to 1.20, because 1.16 is eosl.
